### PR TITLE
move action to object_buttons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.2 - Unreleased
 ------------------
 
+- move action to object_buttons
+  [ebrehault]
+
 - update to use z3c.form so it'll work with Plone 5
   [vangheem]
 

--- a/Products/RedirectionTool/profiles/default/actions.xml
+++ b/Products/RedirectionTool/profiles/default/actions.xml
@@ -2,7 +2,7 @@
 <object name="portal_actions" meta_type="Plone Actions Tool"
    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
    i18n:domain="RedirectionTool">
- <object name="object" meta_type="CMF Action Category">
+ <object name="object_buttons" meta_type="CMF Action Category">
   <object name="redirection" meta_type="CMF Action" i18n:domain="RedirectionTool">
    <property name="title" i18n:translate="">Aliases</property>
    <property name="description" i18n:translate=""></property>


### PR DESCRIPTION
In Plone 5, I think it is not very nice to add extra buttons in the `object` category, as they will appear directly in the toolbar root (most part of time without any icon so it is render as an empty slot). I prefer to put them in `object_buttons` so they are listed in the "More options" menu.

@vangheem, any UX/UI opinion about it ?